### PR TITLE
fix: incorrect letter case in `switch` block

### DIFF
--- a/voicebox/v_ssubmmse.m
+++ b/voicebox/v_ssubmmse.m
@@ -415,7 +415,7 @@ if nr>0
                     gg(:,:,i)=repmat(gam,1,npg);
                 case 'x'            % 'x' = prior SNR (nc)
                     gg(:,:,i)=repmat(x,1,npg);
-                case 'g'            % 'G' = raw gain (nc)
+                case 'G'            % 'G' = raw gain (nc)
                     gg(:,:,i)=repmat(gr,1,npg);
                 case 'g'            % 'g' = final gain (nc)
                     gg(:,:,i)=repmat(g,1,npg);


### PR DESCRIPTION
Dear Mike,

I found this potential typo while checking out your repository.

I don't know how critical this might be, but MATLAB Code Analyser considered the previous state of this code as an error (it had two consecutive matches against lower-case `g`)